### PR TITLE
fix: support crossterm's BackTab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.9.1
+
+### 🐛 Bug Fixes
+- Properly handle crossterm's `BackTab` key when converting to `Input` by @bentheiii in [#25](https://github.com/ratatui/ratatui-textarea/pull/25)
+
 ## 0.9.0 - 2026-04-06
 
 We're excited to announce the new version of **ratatui-textarea**! 🎉

--- a/src/input/crossterm.rs
+++ b/src/input/crossterm.rs
@@ -46,9 +46,19 @@ impl From<KeyEvent> for Input {
             // key release event can be reported. Ignore it. (#14)
             return Self::default();
         }
-
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
         let alt = key.modifiers.contains(KeyModifiers::ALT);
+
+        if key.code == KeyCode::BackTab {
+            // `crossterm` does not support Shift+Tab, but reports it as BackTab.
+            return Self {
+                key: Key::Tab,
+                shift: true,
+                ctrl,
+                alt,
+            };
+        }
+
         let shift = key.modifiers.contains(KeyModifiers::SHIFT);
         let key = Key::from(key.code);
 


### PR DESCRIPTION
Added support for converting a crossterm `BackTab` into a Shift+Tab Input. Fixes #24 